### PR TITLE
Custom hub docker image

### DIFF
--- a/.github/workflows/build_hub_image.yml
+++ b/.github/workflows/build_hub_image.yml
@@ -1,0 +1,56 @@
+name: Build custom hub image
+
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Image tag
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # see https://github.com/docker/build-push-action
+    steps:
+      # Setup (see https://github.com/docker/build-push-action)
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@6520a2d2cb6db42c90c297c8025839c98e531268
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@044aaa9258972fc1ab44730789e42d66b720789c
+      - name: Login to DockerHub
+        uses: docker/login-action@adb73476b6e06caddec5db0bc1deacbec8cdd947
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Publish to Docker hub
+      - name: Store version number (on release)
+        if: ${{ github.event_name == 'release' }}
+        id: version
+        # GITHUB_REF looks like "refs/tags/0.3.1" - we need to extract the actual version without the v prefix
+        run: echo ::set-output name=number::${GITHUB_REF##*/}
+      - name: Build and push (on release)
+        if: ${{ github.event_name == 'release' }}
+        uses: docker/build-push-action@6efc2b01cbb63cfc68c370c6c806586fa6384a3a
+        with:
+          push: true
+          context: jupyterhub
+          file: jupyterhub/Dockerfile
+          tags: |
+            blsq/openhexa-jupyterhub:${{ steps.version.outputs.number }}
+            blsq/openhexa-jupyterhub:latest
+      - name: Build and push (manual)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: docker/build-push-action@6efc2b01cbb63cfc68c370c6c806586fa6384a3a
+        with:
+          push: true
+          context: jupyterhub
+          file: jupyterhub/Dockerfile
+          tags: |
+            blsq/openhexa-jupyterhub:${{ github.event.inputs.tag }}
+            blsq/openhexa-jupyterhub:latest
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@ version: '3'
 
 services:
   jupyterhub:
-    build: jupyterhub
+    build:
+      context: jupyterhub
+      dockerfile: Dockerfile.dev
     command: ["jupyterhub", "-f", "/etc/jupyterhub/jupyterhub_dev_config.py"]
     container_name: jupyterhub
     depends_on:

--- a/jupyterhub/Dockerfile
+++ b/jupyterhub/Dockerfile
@@ -1,4 +1,4 @@
-# It is crucial to use the same jupyterhub version than the one used by z2jh
+# The version here MUST match the z2jh chart version
 FROM jupyterhub/k8s-hub:1.1.1
 
 COPY config/jupyterhub_config.py /usr/local/etc/jupyterhub/jupyterhub_config.d/

--- a/jupyterhub/Dockerfile
+++ b/jupyterhub/Dockerfile
@@ -1,9 +1,4 @@
-# This Dockerfile is only intended for development
-# (In z2jh mode, we use the image provided by the Zero to Jupyterhub Helm chart)
 # It is crucial to use the same jupyterhub version than the one used by z2jh
-FROM jupyterhub/jupyterhub:1.4.1
+FROM jupyterhub/k8s-hub:1.1.1
 
-COPY config/* /etc/jupyterhub/
-
-RUN pip install --upgrade pip
-RUN pip install dockerspawner==12.* psycopg2-binary==2.*
+COPY config/jupyterhub_config.py /usr/local/etc/jupyterhub/jupyterhub_config.d/

--- a/jupyterhub/Dockerfile.dev
+++ b/jupyterhub/Dockerfile.dev
@@ -1,0 +1,9 @@
+# This Dockerfile is only intended for development
+# (In z2jh mode, we use the image provided by the Zero to Jupyterhub Helm chart)
+# It is crucial to use the same jupyterhub version than the one used by z2jh
+FROM jupyterhub/jupyterhub:1.4.1
+
+COPY config/* /etc/jupyterhub/
+
+RUN pip install --upgrade pip
+RUN pip install dockerspawner==12.* psycopg2-binary==2.*

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -49,6 +49,7 @@ module "release" {
   source            = "../modules/release"
   environment       = "demo"
   domain            = "notebooks.demo.openhexa.org"
+  hub_image_tag     = "1.1.1"
   user_image_tag    = "0.3.3"
   user_cpu_limit    = 2
   user_memory_limit = "4G"

--- a/terraform/modules/release/base_config.yaml
+++ b/terraform/modules/release/base_config.yaml
@@ -64,10 +64,6 @@ hub:
         path: /etc/ssl/certs
     - name: cloudsql
       emptyDir: { }
-  extraFiles:
-    jupyterhub_config:
-      binaryData:
-      mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/jupyterhub_config.py
 singleuser:
   image:
     name:

--- a/terraform/modules/release/main.tf
+++ b/terraform/modules/release/main.tf
@@ -54,11 +54,6 @@ EOT
     name  = "hub.db.url"
     value = "postgresql://hexa-notebooks-${var.environment}@127.0.0.1:5432/hexa-notebooks-${var.environment}"
   }
-  # see https://github.com/hashicorp/terraform-provider-helm/issues/628
-  set {
-    name  = "hub.extraFiles.jupyterhub_config.binaryData"
-    value = base64encode(file("${path.module}/../../../jupyterhub/config/jupyterhub_config.py"))
-  }
 
   # Single User
   set {

--- a/terraform/modules/release/variables.tf
+++ b/terraform/modules/release/variables.tf
@@ -6,6 +6,15 @@ variable "domain" {
   description = "The domain through with the app component will be accessed"
   type        = string
 }
+variable "hub_image_name" {
+  description = "The name of the hub image to use"
+  type        = string
+  default     = "blsq/openhexa-jupyterhub"
+}
+variable "hub_image_tag" {
+  description = "The tag of the hub image to use"
+  type        = string
+}
 variable "user_image_name" {
   description = "The name of the single-user server image to use"
   type        = string


### PR DESCRIPTION
This PR embeds our custom "hub" code (`jupyterhub_config` for now) in a custom Docker image.

This will allow us to deploy a self-contained Docker image, without relying on extra files to be mounted at deploy time.