### PR TITLE
Update Z2JH chart version to 2.0

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/datascience-notebook:4b830d5897d8
+FROM jupyter/datascience-notebook:2023-01-24
 
 USER root
 

--- a/jupyterhub/Dockerfile
+++ b/jupyterhub/Dockerfile
@@ -1,4 +1,4 @@
 # The version here MUST match the z2jh chart version
-FROM jupyterhub/k8s-hub:1.2.0
+FROM jupyterhub/k8s-hub:2.0.0
 
 COPY config/jupyterhub_config.py /usr/local/etc/jupyterhub/jupyterhub_config.d/

--- a/jupyterhub/Dockerfile.dev
+++ b/jupyterhub/Dockerfile.dev
@@ -1,7 +1,7 @@
 # This Dockerfile is only intended for development
 # (In z2jh mode, we use the image provided by the Zero to Jupyterhub Helm chart)
 # It is crucial to use the same jupyterhub version than the one used by z2jh
-FROM jupyterhub/jupyterhub:1.4.1
+FROM jupyterhub/jupyterhub:3.0.0
 
 COPY config/* /etc/jupyterhub/
 


### PR DESCRIPTION
This PR :

- [x] Updates the base image notebooks to comply with latest hub chart version
- [x] Updates our dev image so that it uses jupyterhub 3.0
- [x] Updates the prod image so that it uses k8s-hub (z2jh) 2.0