### PR TITLE
feat(Workspaces): Support mounting the workspace bucket in jupyterhub

### DIFF
--- a/jupyter/fuse/fuse_mount.py
+++ b/jupyter/fuse/fuse_mount.py
@@ -78,7 +78,8 @@ if GCS_TOKEN:
         base64.b64decode(os.environ.get("GCS_BUCKETS", b"e30="))
     )
     for bucket in filter(None, gcsfuse_buckets.get("buckets", [])):
-        path_to_mount = f"/home/jovyan/gcs-{bucket['name']}"
+        mount_point = bucket.get("mount", f"/gcs-{bucket['name']}")
+        path_to_mount = "/home/jovyan" + mount_point
         subprocess.run(["mkdir", "-p", path_to_mount])
         args = [
             "gcsfuse",


### PR DESCRIPTION
Re-use the `GCS_TOKEN` as credentials for the workspace
Add a "mount" configuration key to the given buckets list to be able to set the name of the mount point from the backend (and thus differentiate "/workspace" bucket from other buckets with their names)