### PR TITLE
fix(Workspaces): No readme.md should be copied at the root

### DIFF
--- a/jupyter/scripts/wrap_up.py
+++ b/jupyter/scripts/wrap_up.py
@@ -1,12 +1,12 @@
-import os, subprocess
+import os
+import subprocess
 
 if os.environ["OPENHEXA_LEGACY"] == "true":
     # Copy README
-    subprocess.run(["cp", "/tmp/notebooks_sample_files/legacy/README.md", "/home/jovyan/README.md"])
+    subprocess.run(
+        ["cp", "/tmp/notebooks_sample_files/legacy/README.md", "/home/jovyan/README.md"]
+    )
 else:
-    # Copy README
-    subprocess.run(["cp", "/tmp/notebooks_sample_files/README.md", "/home/jovyan/README.md"])
-
     # Delete work directory if any, and create tmp instead
     subprocess.run(["rmdir", "/home/jovyan/work"])
     subprocess.run(["mkdir", "/home/jovyan/tmp"])


### PR DESCRIPTION
Let's use the wiki instead of the README.MD file at the root to explain how to use the notebooks