### PR TITLE
feat(Credentials): Use the new credentials endpoint to get env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       HUB_DB_URL: postgresql://postgres:postgres@postgres:5432/jupyterhub
       AUTHENTICATION_URL: http://host.docker.internal:8000/notebooks/authenticate/
       DEFAULT_CREDENTIALS_URL: http://host.docker.internal:8000/notebooks/default-credentials/
-      WORKSPACE_CREDENTIALS_URL: http://host.docker.internal:8000/workspaces/<workspace_slug>/credentials/
+      WORKSPACE_CREDENTIALS_URL: http://host.docker.internal:8000/workspaces/credentials/
       LOGOUT_REDIRECT_URL: http://host.docker.internal:8000/
       CONTENT_SECURITY_POLICY: "frame-ancestors 'self' localhost:*"
       JUPYTERHUB_CRYPT_KEY: 0b9c2791baa0b19e10f1dc9c4a1a702dda0a37c332378870e9542271a365b9b8


### PR DESCRIPTION
We also remove the GCS_BUCKETS handling since we only manage the workspace gcs bucket.

This is linked to https://github.com/BLSQ/openhexa-app/pull/488