### PR TITLE
fix(Extensions): replace jupyter-dash(deprecated) by dash

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -118,7 +118,7 @@ RUN pip install -U \
 
 # Jupyter extensions
 RUN mamba install -c conda-forge --yes \
-    'jupyter-dash=0.*' \
+    'dash=2.*' \
     'jupyter-resource-usage=0.*' \
     'jupyter-server-proxy=3.*' \
     'jupyterlab_code_formatter=1.*' \


### PR DESCRIPTION
Relative to [issue](https://github.com/BLSQ/openhexa-team/issues/487) :   the  jupyter_dash plugin was duplicated thus showing an error message to the notebook users .

See also : https://github.com/plotly/dash/releases/tag/v2.11.0