### PR TITLE
fix: pin r-arrow & pyarrow to current working production version

### DIFF
--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -39,7 +39,7 @@ USER ${NB_UID}
 
 # R packages (mamba + conda-forge)
 RUN mamba install --yes -c conda-forge \
-    'r-arrow=7.*' \
+    'r-arrow=11.0.0' \
     'r-aws.s3=0.*' \
     'r-geojsonio=0.*' \
     'r-getpass=0.*' \
@@ -93,7 +93,7 @@ RUN mamba install --yes -c conda-forge \
     'papermill==2.*' \
     'plotly=5.*' \
     'psycopg2=2.*' \
-    'pyarrow=7.*' \
+    'pyarrow=11.0.0' \
     'rapidfuzz=2.*' \
     'rasterstats=0.*' \
     'rpy2=3.*' \


### PR DESCRIPTION
So, it seems :

- That it was the `r-arrow=7.*` & `pyarrow=7.*` requirements that were blocking the build process (mamba was completely stuck)
- The image currently used in production was built with those exact requirements, but when I ran `mamba list | grep arrow`, it appeared that both `r-arrow` & `pyarrow` are at version 11 (but why?)

This PR pins both `r-arrow` and `pyarrow` at the exact version currently running in our production environment.

This change seems to fix our build issue.