### PR TITLE
Fix failing notebook start when local

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     environment:
       LOAD_DEV_CONFIG: "true"
       JUPYTER_IMAGE: openhexa-base-notebook
-      DOCKER_NETWORK_NAME: openhexa-notebooks_default
+      DOCKER_NETWORK_NAME: openhexa
       HUB_IP: jupyterhub
       HUB_DB_URL: postgresql://postgres:postgres@postgres:5432/jupyterhub
       AUTHENTICATION_URL: http://app:8000/notebooks/authenticate/

--- a/jupyterhub/config/jupyterhub_dev_config.py
+++ b/jupyterhub/config/jupyterhub_dev_config.py
@@ -22,6 +22,7 @@ c.JupyterHub.hub_connect_ip = os.environ[
 c.JupyterHub.spawner_class = "dockerspawner.DockerSpawner"
 c.DockerSpawner.image = os.environ["JUPYTER_IMAGE"]
 c.Spawner.debug = True  # Seems necessary to see spawner logs / to check
+c.Spawner.cmd = "singleuser"
 c.DockerSpawner.debug = True
 c.DockerSpawner.extra_host_config = {"privileged": True, "devices": "/dev/fuse"}
 c.DockerSpawner.post_start_cmd = 'sh -c "python3 /home/jovyan/.hexa_scripts/fuse_mount.py;python3 /home/jovyan/.hexa_scripts/wrap_up.py"'


### PR DESCRIPTION
When running locally the JupyterHub, we can't spawn a notebook. In the logs, the container creation returns a 204 HTTP status, i.e. created, but the container can't be found when listing them.

After having checked that the host Docker engine is accessible, it appears that the container was crashing immediatly. We could confirm that by reproducing the running command use to start the container. It was retrieved thanks to @pvanliefland. This command is `/bin/bash -o pipefail -c singleuser`. But the entrypoint of the notebook expects the one of the following command: `notebook`, `singleuser`, `pipeline`, or `help`.

According to the [JupyterHub DockerSpawner document](https://jupyterhub-dockerspawner.readthedocs.io/en/latest/api/index.html#dockerspawner.DockerSpawner.image), it's possible to change the command passed to run a container by setting `c.Spawner.cmd` in the config. That's the fix.