### PR TITLE
Fix jupyterhub logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.env
+*.venv
 .coverage
 
 helm/*

--- a/jupyterhub/config/jupyterhub_config.py
+++ b/jupyterhub/config/jupyterhub_config.py
@@ -161,6 +161,7 @@ class AppAuthenticatorLogoutHandler(LogoutHandler):
     async def get(self):
         # Authenticate the user using the sessionid and csrftoken in the cookies
         authenticated = await self.authenticate({})
+        user = None
         if authenticated:
             user = self.find_user(authenticated["name"])
         # We override the _jupyterhub_user attribute to make sure that the logout operation will be performed


### PR DESCRIPTION
We authenticate again the user when the backend calls `/hub/logout` in order to reset its `cookie_id` and for the user to log in again.

The servers already spawned for the user are stopped.