### PR TITLE
HEXA-1093 setup CORS JupyterHub and notebook when behind proxy

### DIFF
--- a/jupyterhub/config/jupyterhub_dev_config.py
+++ b/jupyterhub/config/jupyterhub_dev_config.py
@@ -12,15 +12,26 @@ load_subconfig(str(main_config_file_path.resolve()))
 
 # Configure the hub ip
 # (unnecessary in z2jh mode)
-c.JupyterHub.hub_ip = "0.0.0.0"  # listen on all interfaces
-c.JupyterHub.hub_connect_ip = os.environ[
-    "HUB_IP"
-]  # ip as seen on the docker network. Can also be a hostname.
+# listen on all interfaces
+c.JupyterHub.hub_ip = "0.0.0.0"
+# ip as seen on the docker network. Can also be a hostname.
+c.JupyterHub.hub_connect_ip = os.environ["HUB_IP"]
 
 # Docker Spawner configuration (see https://github.com/jupyterhub/dockerspawner)
 # (In z2jh mode, Kubespawner is used instead)
 
 c.JupyterHub.spawner_class = "dockerspawner.DockerSpawner"
+if os.environ.get('PROXY_HOSTNAME_AND_PORT') is not None:
+    scheme = 'https' if os.environ.get(
+        'TRUST_FORWARDED_PROTO') == 'true' else 'http'
+    url = os.environ.get('PROXY_HOSTNAME_AND_PORT')
+    origin = f'{scheme}://{url}'
+    c.DockerSpawner.args = [f'--NotebookApp.allow_origin={origin}']
+    c.JupyterHub.tornado_settings = {
+        'headers': {
+            'Access-Control-Allow-Origin': origin,
+        },
+    }
 c.DockerSpawner.image = os.environ["JUPYTER_IMAGE"]
 c.DockerSpawner.allowed_images = (
     "*"  # To allow all images to be used via user_options (needed for workspaces)
@@ -28,7 +39,10 @@ c.DockerSpawner.allowed_images = (
 c.Spawner.debug = True  # Seems necessary to see spawner logs / to check
 c.Spawner.cmd = "singleuser"
 c.DockerSpawner.debug = True
-c.DockerSpawner.extra_host_config = {"privileged": True, "devices": "/dev/fuse"}
+c.DockerSpawner.extra_host_config = {
+    "privileged": True,
+    "devices": "/dev/fuse"
+}
 c.DockerSpawner.post_start_cmd = 'sh -c "python3 /home/jovyan/.hexa_scripts/fuse_mount.py && python3 /home/jovyan/.hexa_scripts/wrap_up.py"'
 
 # This is really useful to avoid "dangling containers" that cannot connect to the Hub anymore


### PR DESCRIPTION
We detect based on the env var `PROXY_HOSTNAME_AND_PORT` if OpenHexa runs behind a proxy or not. If so, we configure the CORS for JupyterHub and run notebook